### PR TITLE
[Misc] Sonar: analysis folders updated

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,8 +7,9 @@ sonar.organization=sap-1
 # Go!
 sonar.language=go
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=internal
+sonar.sources=pkg,internal
 sonar.exclusions=**/*_test.go
+sonar.coverage.exclusions=pkg/operator/operator.go
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 


### PR DESCRIPTION
We want the files under pkg and internal to be part of Sonar analysis. We just want to exclude pkg/operator/operator.go from coverage aspect