### PR TITLE
Remove latest tag for helm releases

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         tag: ${{ steps.get_tag.outputs.tag }}
         commit: ${{ steps.get_target_commit.outputs.sha }}
-        makeLatest: true
+        makeLatest: false
         prerelease: false
         allowUpdates: false
   


### PR DESCRIPTION
Remove the latest tag for helm releases. We will use the latest tag only for manager releases so that we can refer to the release artifacts via url **https://github.com/SAPsap/cap-operator-lifecycle/releases/latest/download/manager_manifest.yaml** instead of providing tag specific URL's in the documentations.