### PR TITLE
remove controller access to get CRDs

### DIFF
--- a/chart/templates/controller-rbac.yaml
+++ b/chart/templates/controller-rbac.yaml
@@ -56,9 +56,6 @@ rules:
 - apiGroups: ["monitoring.coreos.com"]
   resources: ["servicemonitors"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
NOTE: this change is linked to https://github.com/SAP/cap-operator/pull/147 and should be merged only after the corresponding cap-operation version (chart -> appVersion) is updated.