### PR TITLE
[Helm] Update server-networking.yaml - Add secretRef.namespace in cert.gardener.cloud/v1alpha1

### DIFF
--- a/chart/templates/server-networking.yaml
+++ b/chart/templates/server-networking.yaml
@@ -34,6 +34,7 @@ spec:
   - {{.Values.subscriptionServer.domain}}
   secretRef:
     name: {{.Release.Name}}-subscription-server-gardener
+    namespace: {{.Values.subscriptionServer.istioSystemNamespace}}
   {{- if .Values.subscriptionServer.certificateConfig.gardener.issuerName }}
   issuerRef:
     name: {{.Values.subscriptionServer.certificateConfig.gardener.issuerName}}


### PR DESCRIPTION
Fix for UPGRADE FAILED: conflict occurred while applying object istio-system/cop-subscription-server cert.gardener.cloud/v1alpha1, Kind=Certificate: Apply failed with 1 conflict: conflict with "cert-controller-manager" using cert.gardener.cloud/v1alpha1: .spec.secretRef